### PR TITLE
Fix ValueError in str_to_oct()

### DIFF
--- a/bashfuck.py
+++ b/bashfuck.py
@@ -20,7 +20,7 @@ def str_to_oct(cmd):
     """
     s = "$\\'"
     for _ in cmd:
-        o = ('%s' % (oct(ord(_)).lstrip('0'))).rjust(3, '0')
+        o = ('%s' % (oct(ord(_)).lstrip('0o'))).rjust(3, '0')
         e = '\\\\' + ''.join(n[int(d)] for d in o)
         s += e
     s += "\\'"


### PR DESCRIPTION
When converting a string to octal you get a representation like '0o145',
then you strip the initial '0' having 'o145' as result instead of just '145'.
This will lead to "ValueError: invalid literal for int() with base 10: 'o'"
(tested on Python 3.7.4)